### PR TITLE
[add] webpack cacheable flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = function(jsCode, inMap) {
       sourceMap: inMap,
     });
   }
+  if (this.cacheable) {
+    this.cacheable();
+  }
   var poweredCodeWithMap = espower(jsCode, filepath, options);
   var outMap = convert.fromSource(poweredCodeWithMap);
   this.callback(null, convert.removeComments(poweredCodeWithMap), outMap.toObject());


### PR DESCRIPTION
Hello, I love this loader.

Why this loader has not webpack `cacheable` flag?
If there is not a reason, may I add it?

before : **not cacheable**
![before](https://cloud.githubusercontent.com/assets/10104981/9697094/a7f2c776-53ba-11e5-92ba-dabf620546c4.png)

after : **cacheable**
![after](https://cloud.githubusercontent.com/assets/10104981/9697119/80c47770-53bb-11e5-85c8-a8d8a96c830a.png)

Thanks.
