### PR TITLE
this.options deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.11"
+  - "lts/*"
 script:
   - "npm run lint"
   - "npm test"

--- a/README.md
+++ b/README.md
@@ -33,34 +33,30 @@ $ npm install --save-dev webpack-espower-loader
 
 ## Usage
 
-Configure `webpack.config.js` to apply `webpack-espower-loader` through webpack loader transformation chain.
-
-```js
-{
-    module: {
-        loaders: [
-            { test: /_test\.js$/, loader: "webpack-espower-loader" }
-        ]
-    }
-}
-```
-
-You can pass espower options by including to webpack configuration object (e.g. webpack.config.js).
+Configure `webpack.config.js` to apply `webpack-espower-loader` through webpack loader transformation chain. Options are passed through to espower.
 If not passed, default options (Same as [espower.defaultOptions()](https://github.com/power-assert-js/espower#var-options--espowerdefaultoptions)) will be used.
 
 ```js
 {
-    espower: {
-        patterns: [
-            'assert(value, [message])',
-            'assert.ok(value, [message])',
-            'assert.equal(actual, expected, [message])',
-            'assert.notEqual(actual, expected, [message])',
-            'assert.strictEqual(actual, expected, [message])',
-            'assert.notStrictEqual(actual, expected, [message])',
-            'assert.deepEqual(actual, expected, [message])',
-            'assert.notDeepEqual(actual, expected, [message])'
-        ]
+    module: {
+        rules: [{
+            test: /_test\.js$/,
+            use: [{
+                loader: "webpack-espower-loader",
+                options: {
+                    patterns: [
+                        'assert(value, [message])',
+                        'assert.ok(value, [message])',
+                        'assert.equal(actual, expected, [message])',
+                        'assert.notEqual(actual, expected, [message])',
+                        'assert.strictEqual(actual, expected, [message])',
+                        'assert.notStrictEqual(actual, expected, [message])',
+                        'assert.deepEqual(actual, expected, [message])',
+                        'assert.notDeepEqual(actual, expected, [message])'
+                    ]
+                }
+            }
+        }]
     }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -12,10 +12,11 @@
 var convert = require('convert-source-map');
 var espower = require('espower-source');
 var extend = require('xtend');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(jsCode, inMap) {
   var filepath = this.resourcePath;
-  var options = this.options.espower;
+  var options = loaderUtils.getOptions(this) || {};
   if (inMap) {
     options = extend(options, {
       sourceMap: inMap,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "convert-source-map": "^1.1.1",
     "espower-source": "^2.0.0",
+    "loader-utils": "^1.1.0",
     "xtend": "^4.0.0"
   }
 }


### PR DESCRIPTION
`this.options` has been deprecated for some time in webpack and webpack 4
(currently in beta) removes it completely.

This uses the [loader-utils](https://github.com/webpack/loader-utils) package to fetch the
options from the loader config's options hash.

Also brings the README up to date.